### PR TITLE
refactor(oauth): drop per-stack casing and PATCH secret validation (camelCase everywhere)

### DIFF
--- a/kbc/kbcapi_scripts.py
+++ b/kbc/kbcapi_scripts.py
@@ -801,19 +801,6 @@ def get_schedules(region: str, master_token: str):
     return _get_paged_schedules(region, master_token)
 
 
-def _convert_payload_to_camel_case(payload: dict):
-    """Converts the payload keys to camelCase"""
-
-    def snake_to_camel(name: str):
-        # split underscore using split
-        temp = name.split('_')
-
-        # joining result
-        return temp[0] + ''.join(ele.title() for ele in temp[1:])
-
-    return {snake_to_camel(k): v for k, v in payload.items()}
-
-
 def list_oauth_consumers(stack: str, master_token: str, filter_response: bool = True):
     """
     Get all oatuh consumers
@@ -839,10 +826,7 @@ def list_oauth_consumers(stack: str, master_token: str, filter_response: bool = 
 
     response_json = response.json()
     if filter_response:
-        if 'gcp' in stack:
-            return [{"component_id": r["componentId"], "name": r["friendlyName"]} for r in response_json]
-        else:
-            return [{"component_id": r["id"], "name": r["friendly_name"]} for r in response_json]
+        return [{"component_id": r["componentId"], "name": r["friendlyName"]} for r in response_json]
     else:
         return response_json
 
@@ -887,8 +871,6 @@ def create_oauth_consumer(stack: str, master_token: str, payload: dict, **kwargs
         'Content-Type': 'application/json',
         'X-KBC-ManageApiToken': master_token,
     }
-    if 'gcp' in stack:
-        payload = _convert_payload_to_camel_case(payload)
     response = requests.post(
         f'https://oauth.{stack}/manage',
         headers=headers, json=payload)
@@ -905,8 +887,6 @@ def patch_oauth_consumer(stack: str, master_token: str, component_id: str, paylo
         'Content-Type': 'application/json',
         'X-KBC-ManageApiToken': master_token,
     }
-    if 'gcp' in stack:
-        payload = _convert_payload_to_camel_case(payload)
     response = requests.patch(
         f'https://oauth.{stack}/manage/{component_id}',
         headers=headers, json=payload)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -132,11 +132,6 @@ def display_main_content():
             st.error("Please provide the payload.")
             return
 
-        if operation == 'PATCH' and payload_json and not 'app_secret' in payload_json:
-            st.error("Please provide the app_secret in the payload, "
-                     "otherwise it will be rewritten with invalid value on PATCH")
-            return
-
         if st.button("EXECUTE", type="primary"):
             filtered_stack_tokens = {stack: stack_tokens_json[stack] for stack in selected_stacks}
             consumer_responses = _perform_consumer_operation(filtered_stack_tokens, operation, payload=payload_json,


### PR DESCRIPTION
## Context

All Keboola stacks now run the new PHP `oauth-service`, which expects **camelCase** consumer payloads (`appKey`, `appSecret`, `authUrl`, …). Verified against AWS and confirmed by the `oauth-service` owner. The tool's old per-stack casing logic (`'gcp' in stack` → camelCase, everything else → snake_case) is therefore obsolete — and was actively wrong for stacks that migrated (e.g. Azure North Europe), forcing manual payload edits.

## Changes

- **Remove the GCP-only `_convert_payload_to_camel_case` converter.** `CREATE`/`PATCH` now send the payload as-is (camelCase, matching the API and the swagger contract).
- **Parse `LIST` responses as camelCase only.** The old non-gcp branch read `id`/`friendly_name`, which breaks once those stacks are on the camelCase service.
- **Remove the `PATCH` `app_secret` validation** that rejected a correct camelCase `appSecret`.

Net: `+1 / −26`. The GCP `GET`-via-list fallback in `get_oauth_consumers` is left untouched — it's an endpoint-routing workaround, unrelated to casing.

## Verification

- `py_compile` passes; no dangling references to the removed converter; `ruff` clean on the changed regions (the one `F841` is pre-existing, unrelated code).

Note: if any stack is ever *not* on the new service, its snake_case payload would need handling again — but per the owner that migration is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
